### PR TITLE
feat: add button to copy to clipboard

### DIFF
--- a/src/app/head.tsx
+++ b/src/app/head.tsx
@@ -1,7 +1,6 @@
 export default function Head() {
   return (
     <>
-      <title>Fala Dev</title>
       <meta content="width=device-width, initial-scale=1" name="viewport" />
       <link rel="shortcut icon" href="/favicon.png" type="image/png" />
     </>

--- a/src/app/terminal/fish/page.tsx
+++ b/src/app/terminal/fish/page.tsx
@@ -1,9 +1,9 @@
-import { CodePreview } from "@/components/CodePreview";
-import shiki from "shiki";
+import { CodePreview } from '@/components/CodePreview'
+import shiki from 'shiki'
 
 export const metadata = {
-  title: "Fish",
-};
+  title: 'Fish',
+}
 
 const fishConfig = `if status is-interactive
 # Commands to run in interactive sessions can go here
@@ -23,14 +23,14 @@ starship init fish | source
 if [ -f '/Users/diegofernandes/google-cloud-sdk/path.fish.inc' ]; . '/Users/diegofernandes/google-cloud-sdk/path.fish.inc'; end
 
 # Aliases
-alias cat="bat --theme=\$(defaults read -globalDomain AppleInterfaceStyle &> /dev/null && echo default || echo GitHub)"`;
+alias cat="bat --theme=\$(defaults read -globalDomain AppleInterfaceStyle &> /dev/null && echo default || echo GitHub)"`
 
 export default async function FishConfig() {
   const highlighter = await shiki.getHighlighter({
-    theme: "rose-pine-moon",
-  });
+    theme: 'rose-pine-moon',
+  })
 
-  const code = highlighter.codeToHtml(fishConfig, { lang: "fish" });
+  const code = highlighter.codeToHtml(fishConfig, { lang: 'fish' })
 
-  return <CodePreview code={code} raw={fishConfig} />;
+  return <CodePreview code={code} raw={fishConfig} />
 }

--- a/src/app/terminal/fish/page.tsx
+++ b/src/app/terminal/fish/page.tsx
@@ -1,9 +1,9 @@
-import { CodePreview } from '@/components/CodePreview'
-import shiki from 'shiki'
+import { CodePreview } from "@/components/CodePreview";
+import shiki from "shiki";
 
 export const metadata = {
-  title: 'Fish',
-}
+  title: "Fish",
+};
 
 const fishConfig = `if status is-interactive
 # Commands to run in interactive sessions can go here
@@ -23,14 +23,14 @@ starship init fish | source
 if [ -f '/Users/diegofernandes/google-cloud-sdk/path.fish.inc' ]; . '/Users/diegofernandes/google-cloud-sdk/path.fish.inc'; end
 
 # Aliases
-alias cat="bat --theme=\$(defaults read -globalDomain AppleInterfaceStyle &> /dev/null && echo default || echo GitHub)"`
+alias cat="bat --theme=\$(defaults read -globalDomain AppleInterfaceStyle &> /dev/null && echo default || echo GitHub)"`;
 
 export default async function FishConfig() {
   const highlighter = await shiki.getHighlighter({
-    theme: 'rose-pine-moon',
-  })
+    theme: "rose-pine-moon",
+  });
 
-  const code = highlighter.codeToHtml(fishConfig, { lang: 'fish' })
+  const code = highlighter.codeToHtml(fishConfig, { lang: "fish" });
 
-  return <CodePreview code={code} />
+  return <CodePreview code={code} raw={fishConfig} />;
 }

--- a/src/app/terminal/general/page.tsx
+++ b/src/app/terminal/general/page.tsx
@@ -28,7 +28,7 @@ Theme: https://github.com/austintraver/warp-theme/blob/main/base16_rose_pine_moo
 
 export default async function General() {
   const highlighter = await shiki.getHighlighter({
-    theme: "rose-pine-moon",
+    theme: 'rose-pine-moon',
   });
 
   const code = highlighter.codeToHtml(markdown, { lang: 'md' })

--- a/src/app/terminal/general/page.tsx
+++ b/src/app/terminal/general/page.tsx
@@ -1,9 +1,9 @@
-import { CodePreview } from "@/components/CodePreview";
-import shiki from "shiki";
+import { CodePreview } from '@/components/CodePreview'
+import shiki from 'shiki'
 
 export const metadata = {
-  title: "Terminal",
-};
+  title: 'Terminal',
+}
 
 const markdown = `
 # General
@@ -24,14 +24,14 @@ Warp: https://www.warp.dev/
 For the theme, I chose Rosé Pine Moon variant: 
 
 Theme: https://github.com/austintraver/warp-theme/blob/main/base16_rose_pine_moon.yaml
-`.trim();
+`.trim()
 
 export default async function General() {
   const highlighter = await shiki.getHighlighter({
     theme: "rose-pine-moon",
   });
 
-  const code = highlighter.codeToHtml(markdown, { lang: "md" });
+  const code = highlighter.codeToHtml(markdown, { lang: 'md' })
 
-  return <CodePreview code={code} />;
+  return <CodePreview code={code} />
 }

--- a/src/app/terminal/general/page.tsx
+++ b/src/app/terminal/general/page.tsx
@@ -1,9 +1,9 @@
-import { CodePreview } from '@/components/CodePreview'
-import shiki from 'shiki'
+import { CodePreview } from "@/components/CodePreview";
+import shiki from "shiki";
 
 export const metadata = {
-  title: 'Terminal',
-}
+  title: "Terminal",
+};
 
 const markdown = `
 # General
@@ -24,14 +24,14 @@ Warp: https://www.warp.dev/
 For the theme, I chose Rosé Pine Moon variant: 
 
 Theme: https://github.com/austintraver/warp-theme/blob/main/base16_rose_pine_moon.yaml
-`.trim()
+`.trim();
 
 export default async function General() {
   const highlighter = await shiki.getHighlighter({
-    theme: 'rose-pine-moon',
-  })
+    theme: "rose-pine-moon",
+  });
 
-  const code = highlighter.codeToHtml(markdown, { lang: 'md' })
+  const code = highlighter.codeToHtml(markdown, { lang: "md" });
 
-  return <CodePreview code={code} />
+  return <CodePreview code={code} />;
 }

--- a/src/app/terminal/general/page.tsx
+++ b/src/app/terminal/general/page.tsx
@@ -29,7 +29,7 @@ Theme: https://github.com/austintraver/warp-theme/blob/main/base16_rose_pine_moo
 export default async function General() {
   const highlighter = await shiki.getHighlighter({
     theme: 'rose-pine-moon',
-  });
+  })
 
   const code = highlighter.codeToHtml(markdown, { lang: 'md' })
 

--- a/src/components/CodePreview.tsx
+++ b/src/components/CodePreview.tsx
@@ -13,14 +13,14 @@ interface CodePreviewProps {
 }
 
 export function CodePreview({ code, raw }: CodePreviewProps) {
-  const [hasCopiedToClipboard, setCopiedToClipboard] = useState(false);
+  const [hasCopiedToClipboard, setCopiedToClipboard] = useState(false)
 
   const handleCopyToClipboard = () => {
-    if (!raw) return;
-    navigator.clipboard.writeText(raw);
-    setCopiedToClipboard(true);
-    setTimeout(() => setCopiedToClipboard(false), 2000);
-  };
+    if (!raw) return
+    navigator.clipboard.writeText(raw)
+    setCopiedToClipboard(true)
+    setTimeout(() => setCopiedToClipboard(false), 2000)
+  }
 
   return (
     <>

--- a/src/components/CodePreview.tsx
+++ b/src/components/CodePreview.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState } from "react"
+import clsx from 'clsx'
 import { JetBrains_Mono } from "@next/font/google"
 
 import { Copy as CopyIcon, CheckCircle2 as CheckIcon } from "lucide-react"
@@ -27,17 +28,18 @@ export function CodePreview({ code, raw }: CodePreviewProps) {
       {raw && (
         <button
           onClick={handleCopyToClipboard}
-          className={`absolute flex items-center right-0 mx-8 gap-x-2 font-semibold z-30 bg-[#2B283B] px-3 py-2 rounded-md text-[#8F8CA8] ${hasCopiedToClipboard ? "ring-2 ring-[#065F46]" : ""}`}
+          data-copied={hasCopiedToClipboard}
+          className="absolute flex items-center right-0 mx-8 gap-x-2 text-sm font-medium z-30 bg-[#2a273f] px-3 py-2 rounded-md text-[#E0DEF2] ring-2 ring-[#2b283b] data-[copied=true]:ring-emerald-600"
         >
           {hasCopiedToClipboard ? (
             <>
-              <CheckIcon size={16} color="#065F46" />
-              Copied to Clipboard!
+              <CheckIcon size={16} className="text-emerald-400" />
+              <span className="w-32">Copied!</span>
             </>
           ): (
             <>
               <CopyIcon size={16} />
-              Copy to Clipboard
+              <span className="w-32">Copy to Clipboard</span>
             </>
           )}
         </button>

--- a/src/components/CodePreview.tsx
+++ b/src/components/CodePreview.tsx
@@ -1,18 +1,42 @@
-import { JetBrains_Mono } from "@next/font/google"
+"use client";
 
-const jetBrainsMono = JetBrains_Mono({ subsets: ['latin'] })
+import { useState } from "react";
+import { JetBrains_Mono } from "@next/font/google";
+
+import { Copy as CopyIcon } from "lucide-react";
+
+const jetBrainsMono = JetBrains_Mono({ subsets: ["latin"] });
 
 interface CodePreviewProps {
-  code: string
+  code: string;
+  pureContent: string;
 }
 
-export function CodePreview({ code }: CodePreviewProps) {
+export function CodePreview({ code, pureContent }: CodePreviewProps) {
+  const [copy, setCopy] = useState("Copy to Clipboard");
+
+  const handleCopyToClipboard = () => {
+    navigator.clipboard.writeText(pureContent);
+    setCopy("Copied to Clipboard!");
+    setTimeout(() => setCopy("Copy to Clipboard"), 2000);
+  };
+
   return (
-    <div 
-      id="shiki-code"
-      style={jetBrainsMono.style}
-      className="absolute inset-0 overflow-auto leading-relaxed scrollbar scrollbar-thumb-[#2B283B] scrollbar-track-transparent" 
-      dangerouslySetInnerHTML={{ __html: code }}
-    />
-  )
+    <>
+      {/*  TODO: Conditionally render Clipboard button to a selected group of files */}
+      <button
+        onClick={handleCopyToClipboard}
+        className="absolute flex items-center right-0 mx-8 gap-x-2 font-semibold z-30 bg-[#2B283B] px-3 py-2 rounded-md text-[#8F8CA8]"
+      >
+        <CopyIcon size={16} />
+        {copy}
+      </button>
+      <div
+        id="shiki-code"
+        style={jetBrainsMono.style}
+        className="absolute inset-0 overflow-auto leading-relaxed scrollbar scrollbar-thumb-[#2B283B] scrollbar-track-transparent"
+        dangerouslySetInnerHTML={{ __html: code }}
+      />
+    </>
+  );
 }

--- a/src/components/CodePreview.tsx
+++ b/src/components/CodePreview.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { useState } from "react"
-import clsx from 'clsx'
 import { JetBrains_Mono } from "@next/font/google"
 
 import { Copy as CopyIcon, CheckCircle2 as CheckIcon } from "lucide-react"

--- a/src/components/CodePreview.tsx
+++ b/src/components/CodePreview.tsx
@@ -13,25 +13,33 @@ interface CodePreviewProps {
 }
 
 export function CodePreview({ code, raw }: CodePreviewProps) {
-  const [copy, setCopy] = useState("Copy to Clipboard");
+  const [hasCopiedToClipboard, setCopiedToClipboard] = useState(false);
 
   const handleCopyToClipboard = () => {
     if (!raw) return;
     navigator.clipboard.writeText(raw);
-    setCopy("Copied to Clipboard!");
-    setTimeout(() => setCopy("Copy to Clipboard"), 2000);
+    setCopiedToClipboard(true);
+    setTimeout(() => setCopiedToClipboard(false), 2000);
   };
 
   return (
     <>
-      {/*  TODO: Conditionally render Clipboard button to a selected group of files */}
       {raw && (
         <button
           onClick={handleCopyToClipboard}
-          className="absolute flex items-center right-0 mx-8 gap-x-2 font-semibold z-30 bg-[#2B283B] px-3 py-2 rounded-md text-[#8F8CA8]"
+          className={`absolute flex items-center right-0 mx-8 gap-x-2 font-semibold z-30 bg-[#2B283B] px-3 py-2 rounded-md text-[#8F8CA8] ${hasCopiedToClipboard ? "ring-2 ring-[#065F46]" : ""}`}
         >
-          <CopyIcon size={16} />
-          {copy}
+          {hasCopiedToClipboard ? (
+            <>
+              <CheckIcon size={16} color="#065F46" />
+              Copied to Clipboard!
+            </>
+          ): (
+            <>
+              <CopyIcon size={16} />
+              Copy to Clipboard
+            </>
+          )}
         </button>
       )}
       <div

--- a/src/components/CodePreview.tsx
+++ b/src/components/CodePreview.tsx
@@ -9,14 +9,14 @@ const jetBrainsMono = JetBrains_Mono({ subsets: ["latin"] });
 
 interface CodePreviewProps {
   code: string;
-  pureContent: string;
+  raw: string;
 }
 
-export function CodePreview({ code, pureContent }: CodePreviewProps) {
+export function CodePreview({ code, raw }: CodePreviewProps) {
   const [copy, setCopy] = useState("Copy to Clipboard");
 
   const handleCopyToClipboard = () => {
-    navigator.clipboard.writeText(pureContent);
+    navigator.clipboard.writeText(raw);
     setCopy("Copied to Clipboard!");
     setTimeout(() => setCopy("Copy to Clipboard"), 2000);
   };

--- a/src/components/CodePreview.tsx
+++ b/src/components/CodePreview.tsx
@@ -9,13 +9,14 @@ const jetBrainsMono = JetBrains_Mono({ subsets: ["latin"] });
 
 interface CodePreviewProps {
   code: string;
-  raw: string;
+  raw?: string;
 }
 
 export function CodePreview({ code, raw }: CodePreviewProps) {
   const [copy, setCopy] = useState("Copy to Clipboard");
 
   const handleCopyToClipboard = () => {
+    if (!raw) return;
     navigator.clipboard.writeText(raw);
     setCopy("Copied to Clipboard!");
     setTimeout(() => setCopy("Copy to Clipboard"), 2000);
@@ -24,13 +25,15 @@ export function CodePreview({ code, raw }: CodePreviewProps) {
   return (
     <>
       {/*  TODO: Conditionally render Clipboard button to a selected group of files */}
-      <button
-        onClick={handleCopyToClipboard}
-        className="absolute flex items-center right-0 mx-8 gap-x-2 font-semibold z-30 bg-[#2B283B] px-3 py-2 rounded-md text-[#8F8CA8]"
-      >
-        <CopyIcon size={16} />
-        {copy}
-      </button>
+      {raw && (
+        <button
+          onClick={handleCopyToClipboard}
+          className="absolute flex items-center right-0 mx-8 gap-x-2 font-semibold z-30 bg-[#2B283B] px-3 py-2 rounded-md text-[#8F8CA8]"
+        >
+          <CopyIcon size={16} />
+          {copy}
+        </button>
+      )}
       <div
         id="shiki-code"
         style={jetBrainsMono.style}

--- a/src/components/CodePreview.tsx
+++ b/src/components/CodePreview.tsx
@@ -1,15 +1,15 @@
-"use client";
+'use client'
 
-import { useState } from "react";
-import { JetBrains_Mono } from "@next/font/google";
+import { useState } from "react"
+import { JetBrains_Mono } from "@next/font/google"
 
-import { Copy as CopyIcon } from "lucide-react";
+import { Copy as CopyIcon, CheckCircle2 as CheckIcon } from "lucide-react"
 
-const jetBrainsMono = JetBrains_Mono({ subsets: ["latin"] });
+const jetBrainsMono = JetBrains_Mono({ subsets: ['latin'] })
 
 interface CodePreviewProps {
-  code: string;
-  raw?: string;
+  code: string
+  raw?: string
 }
 
 export function CodePreview({ code, raw }: CodePreviewProps) {
@@ -41,5 +41,5 @@ export function CodePreview({ code, raw }: CodePreviewProps) {
         dangerouslySetInnerHTML={{ __html: code }}
       />
     </>
-  );
+  )
 }

--- a/src/components/Explorer/File.tsx
+++ b/src/components/Explorer/File.tsx
@@ -16,7 +16,7 @@ export function File(props: FileProps) {
   return (
     <Link
       data-active={isCurrentActive}
-      className="flex text-sm items-center gap-2 py-1 px-4 pl-10 hover:bg-[#2B283B] hover:text-[#E0DEF2] data-[active=true]:bg-[#2B283B] data-[active=true]:text-[#E0DEF2]" 
+      className="flex text-sm items-center gap-2 py-1 px-4 pl-10 hover:bg-[#2a273f] hover:text-[#E0DEF2] data-[active=true]:bg-[#2a273f] data-[active=true]:text-[#E0DEF2]" 
       {...props} 
     />
   )

--- a/src/components/Explorer/Folder.tsx
+++ b/src/components/Explorer/Folder.tsx
@@ -15,7 +15,7 @@ export function Folder({ title, children, defaultOpen = false }: FolderProps) {
 
   return (
     <Collapsible.Root open={isOpen} onOpenChange={setIsOpen}>
-      <Collapsible.Trigger className="flex items-center gap-2 px-2 py-1 w-full border border-transparent hover:bg-[#2B283B] hover:text-[#E0DEF2] focus:bg-[#2B283B] focus:border-[#363247] focus:text-[#E0DEF2]">
+      <Collapsible.Trigger className="flex items-center gap-2 px-2 py-1 w-full border border-transparent hover:bg-[#2a273f] hover:text-[#E0DEF2] focus:bg-[#2a273f] focus:border-[#363247] focus:text-[#E0DEF2]">
         {isOpen ? <ChevronDown size={20} /> : <ChevronRight size={20} />}
 
         <FolderIcon size={16} />

--- a/src/components/GistContent.tsx
+++ b/src/components/GistContent.tsx
@@ -1,19 +1,19 @@
-import shiki from 'shiki'
-import { CodePreview } from "./CodePreview"
+import shiki from "shiki";
+import { CodePreview } from "./CodePreview";
 
 interface GistContentProps {
-  gistUrl: string
+  gistUrl: string;
 }
 
 export async function GistContent({ gistUrl }: GistContentProps) {
-  const settingsResponse = await fetch(gistUrl)
-  const settings = await settingsResponse.text()
+  const settingsResponse = await fetch(gistUrl);
+  const settings = await settingsResponse.text();
 
   const highlighter = await shiki.getHighlighter({
-    theme: 'rose-pine-moon',
-  })
+    theme: "rose-pine-moon",
+  });
 
-  const code = highlighter.codeToHtml(settings, { lang: 'json' })
+  const code = highlighter.codeToHtml(settings, { lang: "json" });
 
-  return <CodePreview code={code} />
+  return <CodePreview code={code} pureContent={settings} />;
 }

--- a/src/components/GistContent.tsx
+++ b/src/components/GistContent.tsx
@@ -15,5 +15,5 @@ export async function GistContent({ gistUrl }: GistContentProps) {
 
   const code = highlighter.codeToHtml(settings, { lang: "json" });
 
-  return <CodePreview code={code} pureContent={settings} />;
+  return <CodePreview code={code} raw={settings} />;
 }

--- a/src/components/GistContent.tsx
+++ b/src/components/GistContent.tsx
@@ -1,19 +1,19 @@
-import shiki from "shiki";
-import { CodePreview } from "./CodePreview";
+import shiki from "shiki"
+import { CodePreview } from "./CodePreview"
 
 interface GistContentProps {
-  gistUrl: string;
+  gistUrl: string
 }
 
 export async function GistContent({ gistUrl }: GistContentProps) {
-  const settingsResponse = await fetch(gistUrl);
-  const settings = await settingsResponse.text();
+  const settingsResponse = await fetch(gistUrl)
+  const settings = await settingsResponse.text()
 
   const highlighter = await shiki.getHighlighter({
-    theme: "rose-pine-moon",
-  });
+    theme: 'rose-pine-moon',
+  })
 
-  const code = highlighter.codeToHtml(settings, { lang: "json" });
+  const code = highlighter.codeToHtml(settings, { lang: 'json' })
 
-  return <CodePreview code={code} raw={settings} />;
+  return <CodePreview code={code} raw={settings} />
 }


### PR DESCRIPTION
The website has some big gist files that make the process of selecting to the very end and copying using shortcuts very long, so I implemented a button that copies the raw content of a page to the clipboard.

This PR also makes the CodePreview component client-side rendered.