### PR TITLE
feat: fetching theme from gist

### DIFF
--- a/src/components/GistContent.tsx
+++ b/src/components/GistContent.tsx
@@ -1,3 +1,4 @@
+import { getTheme } from "@/utils/getTheme"
 import shiki from "shiki"
 import { CodePreview } from "./CodePreview"
 
@@ -10,7 +11,7 @@ export async function GistContent({ gistUrl }: GistContentProps) {
   const settings = await settingsResponse.text()
 
   const highlighter = await shiki.getHighlighter({
-    theme: 'rose-pine-moon',
+    theme: await getTheme()
   })
 
   const code = highlighter.codeToHtml(settings, { lang: 'json' })

--- a/src/utils/getTheme.ts
+++ b/src/utils/getTheme.ts
@@ -1,0 +1,21 @@
+export async function getTheme() {
+  const response = await fetch(
+    "https://gist.githubusercontent.com/diego3g/b1b189063d21b96d6144ca896755be64/raw/765a17e8c439d25b1866c1322437a6da2b9e4be8/settings.json"
+  )
+  const data = await response.text()
+
+  let theme = "rose-pine-moon"
+
+  data.split("\n").map((line: string) => {
+    if (line.includes("workbench.colorTheme")) {
+      theme = line
+        .split(": ")[1]
+        .split(" ")
+        .join("-")
+        .replaceAll('"', "")
+        .toLowerCase()
+    }
+  })
+
+  return theme
+}


### PR DESCRIPTION
In Diego's most recent [video](https://www.youtube.com/watch?v=PD9jFWLY8Is) description of what he is looking to build in this project , I noticed how the theme is still statically provided as `rose-pine-moon`. Well, I tried changing that.

There's a small issue:
- @diego3g's Gist does not change whenever he switches his VSCode theme.
- Only the editor colors are changed. This happens because the HTML is styled statically with Tailwind. The first solution that came to mind was somehow getting the colors from [shiki](https://shiki.matsu.io/), and styling accordingly.

I considered using the [Settings Sync](https://marketplace.visualstudio.com/items?itemName=Shan.code-settings-sync) extension from VS Code, but it is deprecated, so I ran out of options.

**OBS:** This is my first experience with contributing and PRs, and as this is a project I wanted to create for myself for a long time but never had the guts to do, this is a great opportunity.