### PR TITLE
feat: add notion as cms

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+# Connection to Notion API
+# see: https://developers.notion.com/docs/create-a-notion-integration
+NOTION_API_KEY=""
+
+# Edge Config is a key-value data store associated with your Vercel account
+# see: https://vercel.com/docs/concepts/edge-network/edge-config/get-started
+EDGE_CONFIG="https://edge-config.vercel.com/your_edge_config_id_here?token=your_edge_config_read_access_token_here"

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "eslint-config-next": "13.1.6",
     "lucide-react": "^0.112.0",
     "next": "13.1.7-canary.7",
+    "notion-client": "^6.16.0",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "shiki": "^0.14.0",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@types/node": "18.13.0",
     "@types/react": "18.0.27",
     "@types/react-dom": "18.0.10",
+    "@vercel/edge-config": "^0.1.1",
     "eslint": "8.33.0",
     "eslint-config-next": "13.1.6",
     "lucide-react": "^0.112.0",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@next/font": "13.1.6",
+    "@notionhq/client": "^2.2.3",
     "@radix-ui/react-collapsible": "^1.0.1",
     "@radix-ui/react-dropdown-menu": "^2.0.2",
     "@radix-ui/react-scroll-area": "^1.0.2",
@@ -20,7 +21,6 @@
     "eslint-config-next": "13.1.6",
     "lucide-react": "^0.112.0",
     "next": "13.1.7-canary.7",
-    "notion-client": "^6.16.0",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "shiki": "^0.14.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,6 +13,7 @@ specifiers:
   eslint-config-next: 13.1.6
   lucide-react: ^0.112.0
   next: 13.1.7-canary.7
+  notion-client: ^6.16.0
   postcss: ^8.4.21
   react: 18.2.0
   react-dom: 18.2.0
@@ -35,6 +36,7 @@ dependencies:
   eslint-config-next: 13.1.6_4vsywjlpuriuw3tl5oq6zy5a64
   lucide-react: 0.112.0_react@18.2.0
   next: 13.1.7-canary.7_biqbaboplfbrettd7655fr4n2y
+  notion-client: 6.16.0
   react: 18.2.0
   react-dom: 18.2.0_react@18.2.0
   shiki: 0.14.0
@@ -642,14 +644,45 @@ packages:
     resolution: {integrity: sha512-sXo/qW2/pAcmT43VoRKOJbDOfV3cYpq3szSVfIThQXNt+E4DfKj361vaAt3c88U5tPUxzEswam7GW48PJqtKAg==}
     dev: false
 
+  /@sindresorhus/is/4.6.0:
+    resolution: {integrity: sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==}
+    engines: {node: '>=10'}
+    dev: false
+
   /@swc/helpers/0.4.14:
     resolution: {integrity: sha512-4C7nX/dvpzB7za4Ql9K81xK3HPxCpHMgwTZVyf+9JQ6VUbn9jjZVN7/Nkdz/Ugzs2CSjqnL/UPXroiVBVHUWUw==}
     dependencies:
       tslib: 2.5.0
     dev: false
 
+  /@szmarczak/http-timer/4.0.6:
+    resolution: {integrity: sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==}
+    engines: {node: '>=10'}
+    dependencies:
+      defer-to-connect: 2.0.1
+    dev: false
+
+  /@types/cacheable-request/6.0.3:
+    resolution: {integrity: sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==}
+    dependencies:
+      '@types/http-cache-semantics': 4.0.1
+      '@types/keyv': 3.1.4
+      '@types/node': 18.13.0
+      '@types/responselike': 1.0.0
+    dev: false
+
+  /@types/http-cache-semantics/4.0.1:
+    resolution: {integrity: sha512-SZs7ekbP8CN0txVG2xVRH6EgKmEm31BOxA07vkFaETzZz1xh+cbt8BcI0slpymvwhx5dlFnQG2rTlPVQn+iRPQ==}
+    dev: false
+
   /@types/json5/0.0.29:
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
+    dev: false
+
+  /@types/keyv/3.1.4:
+    resolution: {integrity: sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==}
+    dependencies:
+      '@types/node': 18.13.0
     dev: false
 
   /@types/node/18.13.0:
@@ -672,6 +705,12 @@ packages:
       '@types/prop-types': 15.7.5
       '@types/scheduler': 0.16.2
       csstype: 3.1.1
+    dev: false
+
+  /@types/responselike/1.0.0:
+    resolution: {integrity: sha512-85Y2BjiufFzaMIlvJDvTTB8Fxl2xfLo4HgmHzVBz08w4wDePCTjYw66PdrolO0kzli3yam/YCgRufyo1DdQVTA==}
+    dependencies:
+      '@types/node': 18.13.0
     dev: false
 
   /@types/scheduler/0.16.2:
@@ -768,6 +807,14 @@ packages:
     resolution: {integrity: sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==}
     engines: {node: '>=0.4.0'}
     hasBin: true
+    dev: false
+
+  /aggregate-error/4.0.1:
+    resolution: {integrity: sha512-0poP0T7el6Vq3rstR8Mn4V/IQrpBLO6POkUSrN7RhyY+GF/InCFShQzsQ39T25gkHhLgSLByyAz+Kjb+c2L98w==}
+    engines: {node: '>=12'}
+    dependencies:
+      clean-stack: 4.2.0
+      indent-string: 5.0.0
     dev: false
 
   /ajv/6.12.6:
@@ -944,6 +991,24 @@ packages:
       update-browserslist-db: 1.0.10_browserslist@4.21.5
     dev: true
 
+  /cacheable-lookup/5.0.4:
+    resolution: {integrity: sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==}
+    engines: {node: '>=10.6.0'}
+    dev: false
+
+  /cacheable-request/7.0.2:
+    resolution: {integrity: sha512-pouW8/FmiPQbuGpkXQ9BAPv/Mo5xDGANgSNXzTzJ8DrKGuXOssM4wIQRjfanNRh3Yu5cfYPvcorqbhg2KIJtew==}
+    engines: {node: '>=8'}
+    dependencies:
+      clone-response: 1.0.3
+      get-stream: 5.2.0
+      http-cache-semantics: 4.1.1
+      keyv: 4.5.2
+      lowercase-keys: 2.0.0
+      normalize-url: 6.1.0
+      responselike: 2.0.1
+    dev: false
+
   /call-bind/1.0.2:
     resolution: {integrity: sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==}
     dependencies:
@@ -985,8 +1050,21 @@ packages:
     optionalDependencies:
       fsevents: 2.3.2
 
+  /clean-stack/4.2.0:
+    resolution: {integrity: sha512-LYv6XPxoyODi36Dp976riBtSY27VmFo+MKqEU9QCCWyTrdEPDog+RWA7xQWHi6Vbp61j5c4cdzzX1NidnwtUWg==}
+    engines: {node: '>=12'}
+    dependencies:
+      escape-string-regexp: 5.0.0
+    dev: false
+
   /client-only/0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
+    dev: false
+
+  /clone-response/1.0.3:
+    resolution: {integrity: sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==}
+    dependencies:
+      mimic-response: 1.0.1
     dev: false
 
   /color-convert/2.0.1:
@@ -1048,6 +1126,13 @@ packages:
       ms: 2.1.2
     dev: false
 
+  /decompress-response/6.0.0:
+    resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
+    engines: {node: '>=10'}
+    dependencies:
+      mimic-response: 3.1.0
+    dev: false
+
   /deep-equal/2.2.0:
     resolution: {integrity: sha512-RdpzE0Hv4lhowpIUKKMJfeH6C1pXdtT1/it80ubgWqwI3qpuxUBpC1S4hnHg+zjnuOoDkzUtUCEEkG+XG5l3Mw==}
     dependencies:
@@ -1072,6 +1157,11 @@ packages:
 
   /deep-is/0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
+    dev: false
+
+  /defer-to-connect/2.0.1:
+    resolution: {integrity: sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==}
+    engines: {node: '>=10'}
     dev: false
 
   /define-lazy-prop/2.0.0:
@@ -1136,6 +1226,12 @@ packages:
 
   /emoji-regex/9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
+    dev: false
+
+  /end-of-stream/1.4.4:
+    resolution: {integrity: sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==}
+    dependencies:
+      once: 1.4.0
     dev: false
 
   /enhanced-resolve/5.12.0:
@@ -1231,6 +1327,11 @@ packages:
   /escape-string-regexp/4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
+    dev: false
+
+  /escape-string-regexp/5.0.0:
+    resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
+    engines: {node: '>=12'}
     dev: false
 
   /eslint-config-next/13.1.6_4vsywjlpuriuw3tl5oq6zy5a64:
@@ -1518,6 +1619,10 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: false
 
+  /eventemitter3/4.0.7:
+    resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
+    dev: false
+
   /fast-deep-equal/3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
     dev: false
@@ -1629,6 +1734,13 @@ packages:
     engines: {node: '>=6'}
     dev: false
 
+  /get-stream/5.2.0:
+    resolution: {integrity: sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==}
+    engines: {node: '>=8'}
+    dependencies:
+      pump: 3.0.0
+    dev: false
+
   /get-symbol-description/1.0.0:
     resolution: {integrity: sha512-2EmdH1YvIQiZpltCNgkuiUnyukzxM/R6NDJX31Ke3BG1Nq5b0S2PhX59UKi9vZpPDQVdqn+1IcaAwnzTT5vCjw==}
     engines: {node: '>= 0.4'}
@@ -1726,6 +1838,23 @@ packages:
       get-intrinsic: 1.2.0
     dev: false
 
+  /got/11.8.6:
+    resolution: {integrity: sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==}
+    engines: {node: '>=10.19.0'}
+    dependencies:
+      '@sindresorhus/is': 4.6.0
+      '@szmarczak/http-timer': 4.0.6
+      '@types/cacheable-request': 6.0.3
+      '@types/responselike': 1.0.0
+      cacheable-lookup: 5.0.4
+      cacheable-request: 7.0.2
+      decompress-response: 6.0.0
+      http2-wrapper: 1.0.3
+      lowercase-keys: 2.0.0
+      p-cancelable: 2.1.1
+      responselike: 2.0.1
+    dev: false
+
   /graceful-fs/4.2.10:
     resolution: {integrity: sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==}
     dev: false
@@ -1772,6 +1901,18 @@ packages:
     dependencies:
       function-bind: 1.1.1
 
+  /http-cache-semantics/4.1.1:
+    resolution: {integrity: sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==}
+    dev: false
+
+  /http2-wrapper/1.0.3:
+    resolution: {integrity: sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==}
+    engines: {node: '>=10.19.0'}
+    dependencies:
+      quick-lru: 5.1.1
+      resolve-alpn: 1.2.1
+    dev: false
+
   /ignore/5.2.4:
     resolution: {integrity: sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==}
     engines: {node: '>= 4'}
@@ -1788,6 +1929,11 @@ packages:
   /imurmurhash/0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
+    dev: false
+
+  /indent-string/5.0.0:
+    resolution: {integrity: sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==}
+    engines: {node: '>=12'}
     dev: false
 
   /inflight/1.0.6:
@@ -1953,6 +2099,11 @@ packages:
       has-tostringtag: 1.0.0
     dev: false
 
+  /is-url-superb/6.1.0:
+    resolution: {integrity: sha512-LXdhGlYqUPdvEyIhWPEEwYYK3yrUiPcBjmFGlZNv1u5GtIL5qQRf7ddDyPNAvsMFqdzS923FROpTQU97tLe3JQ==}
+    engines: {node: '>=12'}
+    dev: false
+
   /is-weakmap/2.0.1:
     resolution: {integrity: sha512-NSBR4kH5oVj1Uwvv970ruUkCV7O1mzgVFO4/rev2cLRda9Tm9HrL70ZPut4rOHgY0FNrUu9BCbXA2sdQ+x0chA==}
     dev: false
@@ -2000,6 +2151,10 @@ packages:
       argparse: 2.0.1
     dev: false
 
+  /json-buffer/3.0.1:
+    resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
+    dev: false
+
   /json-schema-traverse/0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
     dev: false
@@ -2025,6 +2180,12 @@ packages:
     dependencies:
       array-includes: 3.1.6
       object.assign: 4.1.4
+    dev: false
+
+  /keyv/4.5.2:
+    resolution: {integrity: sha512-5MHbFaKn8cNSmVW7BYnijeAVlE4cYA/SVkifVgrh7yotnfhKmjuXpDKjrABLnT0SfHWV21P8ow07OGfRrNDg8g==}
+    dependencies:
+      json-buffer: 3.0.1
     dev: false
 
   /language-subtag-registry/0.3.22:
@@ -2067,6 +2228,11 @@ packages:
       js-tokens: 4.0.0
     dev: false
 
+  /lowercase-keys/2.0.0:
+    resolution: {integrity: sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==}
+    engines: {node: '>=8'}
+    dev: false
+
   /lru-cache/6.0.0:
     resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
     engines: {node: '>=10'}
@@ -2082,6 +2248,21 @@ packages:
       react: 18.2.0
     dev: false
 
+  /map-age-cleaner/0.1.3:
+    resolution: {integrity: sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==}
+    engines: {node: '>=6'}
+    dependencies:
+      p-defer: 1.0.0
+    dev: false
+
+  /mem/9.0.2:
+    resolution: {integrity: sha512-F2t4YIv9XQUBHt6AOJ0y7lSmP1+cY7Fm1DRh9GClTGzKST7UWLMx6ly9WZdLH/G/ppM5RL4MlQfRT71ri9t19A==}
+    engines: {node: '>=12.20'}
+    dependencies:
+      map-age-cleaner: 0.1.3
+      mimic-fn: 4.0.0
+    dev: false
+
   /merge2/1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
@@ -2092,6 +2273,21 @@ packages:
     dependencies:
       braces: 3.0.2
       picomatch: 2.3.1
+
+  /mimic-fn/4.0.0:
+    resolution: {integrity: sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==}
+    engines: {node: '>=12'}
+    dev: false
+
+  /mimic-response/1.0.1:
+    resolution: {integrity: sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==}
+    engines: {node: '>=4'}
+    dev: false
+
+  /mimic-response/3.1.0:
+    resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
+    engines: {node: '>=10'}
+    dev: false
 
   /minimatch/3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
@@ -2175,6 +2371,42 @@ packages:
     resolution: {integrity: sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==}
     engines: {node: '>=0.10.0'}
     dev: true
+
+  /normalize-url/6.1.0:
+    resolution: {integrity: sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==}
+    engines: {node: '>=10'}
+    dev: false
+
+  /normalize-url/7.2.0:
+    resolution: {integrity: sha512-uhXOdZry0L6M2UIo9BTt7FdpBDiAGN/7oItedQwPKh8jh31ZlvC8U9Xl/EJ3aijDHaywXTW3QbZ6LuCocur1YA==}
+    engines: {node: '>=12.20'}
+    dev: false
+
+  /notion-client/6.16.0:
+    resolution: {integrity: sha512-gI2kPpls8XxJfXt7cs2JDmSHPZL1HkkXQnE5YWKPT4OnpiniUgHk5b+rRB2dXUqGT4003vSYmPnxXUTbzKPoLA==}
+    engines: {node: '>=12'}
+    dependencies:
+      got: 11.8.6
+      notion-types: 6.16.0
+      notion-utils: 6.16.0
+      p-map: 5.5.0
+    dev: false
+
+  /notion-types/6.16.0:
+    resolution: {integrity: sha512-Cv83GaAczx57q1qsnuG8DHOuOb63c83u9LX2IainG5aqBEB0GUuLZ4DUQfB6MaXt+FMY9fO+KTgPeZWwX9hbrQ==}
+    engines: {node: '>=12'}
+    dev: false
+
+  /notion-utils/6.16.0:
+    resolution: {integrity: sha512-DxToriZAJW/64O1xlAjyU/50dRmkO1e54+i0dEAPDij0MlHyihEivAMsdEG/6/4eFC972BIsEKZ6BXsSTUYKlQ==}
+    engines: {node: '>=12'}
+    dependencies:
+      is-url-superb: 6.1.0
+      mem: 9.0.2
+      normalize-url: 7.2.0
+      notion-types: 6.16.0
+      p-queue: 7.3.4
+    dev: false
 
   /object-assign/4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
@@ -2273,6 +2505,16 @@ packages:
       word-wrap: 1.2.3
     dev: false
 
+  /p-cancelable/2.1.1:
+    resolution: {integrity: sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==}
+    engines: {node: '>=8'}
+    dev: false
+
+  /p-defer/1.0.0:
+    resolution: {integrity: sha512-wB3wfAxZpk2AzOfUMJNL+d36xothRSyj8EXOa4f6GMqYDN9BJaaSISbsk+wS9abmnebVw95C2Kb5t85UmpCxuw==}
+    engines: {node: '>=4'}
+    dev: false
+
   /p-limit/3.1.0:
     resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
     engines: {node: '>=10'}
@@ -2285,6 +2527,26 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       p-limit: 3.1.0
+    dev: false
+
+  /p-map/5.5.0:
+    resolution: {integrity: sha512-VFqfGDHlx87K66yZrNdI4YGtD70IRyd+zSvgks6mzHPRNkoKy+9EKP4SFC77/vTTQYmRmti7dvqC+m5jBrBAcg==}
+    engines: {node: '>=12'}
+    dependencies:
+      aggregate-error: 4.0.1
+    dev: false
+
+  /p-queue/7.3.4:
+    resolution: {integrity: sha512-esox8CWt0j9EZECFvkFl2WNPat8LN4t7WWeXq73D9ha0V96qPRufApZi4ZhPwXAln1uVVal429HVVKPa2X0yQg==}
+    engines: {node: '>=12'}
+    dependencies:
+      eventemitter3: 4.0.7
+      p-timeout: 5.1.0
+    dev: false
+
+  /p-timeout/5.1.0:
+    resolution: {integrity: sha512-auFDyzzzGZZZdHz3BtET9VEz0SE/uMEAx7uWfGPucfzEwwe/xH0iVeZibQmANYE/hp9T2+UUZT5m+BKyrDp3Ew==}
+    engines: {node: '>=12'}
     dev: false
 
   /parent-module/1.0.1:
@@ -2413,6 +2675,13 @@ packages:
       react-is: 16.13.1
     dev: false
 
+  /pump/3.0.0:
+    resolution: {integrity: sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==}
+    dependencies:
+      end-of-stream: 1.4.4
+      once: 1.4.0
+    dev: false
+
   /punycode/2.3.0:
     resolution: {integrity: sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==}
     engines: {node: '>=6'}
@@ -2527,6 +2796,10 @@ packages:
     engines: {node: '>=8'}
     dev: false
 
+  /resolve-alpn/1.2.1:
+    resolution: {integrity: sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==}
+    dev: false
+
   /resolve-from/4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
@@ -2547,6 +2820,12 @@ packages:
       is-core-module: 2.11.0
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
+    dev: false
+
+  /responselike/2.0.1:
+    resolution: {integrity: sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==}
+    dependencies:
+      lowercase-keys: 2.0.0
     dev: false
 
   /reusify/1.0.4:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,6 +9,7 @@ specifiers:
   '@types/node': 18.13.0
   '@types/react': 18.0.27
   '@types/react-dom': 18.0.10
+  '@vercel/edge-config': ^0.1.1
   autoprefixer: ^10.4.13
   eslint: 8.33.0
   eslint-config-next: 13.1.6
@@ -33,6 +34,7 @@ dependencies:
   '@types/node': 18.13.0
   '@types/react': 18.0.27
   '@types/react-dom': 18.0.10
+  '@vercel/edge-config': 0.1.1
   eslint: 8.33.0
   eslint-config-next: 13.1.6_4vsywjlpuriuw3tl5oq6zy5a64
   lucide-react: 0.112.0_react@18.2.0
@@ -757,6 +759,11 @@ packages:
     dependencies:
       '@typescript-eslint/types': 5.51.0
       eslint-visitor-keys: 3.3.0
+    dev: false
+
+  /@vercel/edge-config/0.1.1:
+    resolution: {integrity: sha512-HDl+12tzW2RHIu8Y804kXg2VpZ02KVb7Nqsa+e1AFoACXXMb+7TfjI1wR19tXoDIu5enQz1dbat40YMEgaH13Q==}
+    engines: {node: '>=14.6'}
     dev: false
 
   /acorn-jsx/5.3.2_acorn@8.8.2:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2,6 +2,7 @@ lockfileVersion: 5.4
 
 specifiers:
   '@next/font': 13.1.6
+  '@notionhq/client': ^2.2.3
   '@radix-ui/react-collapsible': ^1.0.1
   '@radix-ui/react-dropdown-menu': ^2.0.2
   '@radix-ui/react-scroll-area': ^1.0.2
@@ -13,7 +14,6 @@ specifiers:
   eslint-config-next: 13.1.6
   lucide-react: ^0.112.0
   next: 13.1.7-canary.7
-  notion-client: ^6.16.0
   postcss: ^8.4.21
   react: 18.2.0
   react-dom: 18.2.0
@@ -26,6 +26,7 @@ specifiers:
 
 dependencies:
   '@next/font': 13.1.6
+  '@notionhq/client': 2.2.3
   '@radix-ui/react-collapsible': 1.0.1_biqbaboplfbrettd7655fr4n2y
   '@radix-ui/react-dropdown-menu': 2.0.2_5ndqzdd6t4rivxsukjv3i3ak2q
   '@radix-ui/react-scroll-area': 1.0.2_biqbaboplfbrettd7655fr4n2y
@@ -36,7 +37,6 @@ dependencies:
   eslint-config-next: 13.1.6_4vsywjlpuriuw3tl5oq6zy5a64
   lucide-react: 0.112.0_react@18.2.0
   next: 13.1.7-canary.7_biqbaboplfbrettd7655fr4n2y
-  notion-client: 6.16.0
   react: 18.2.0
   react-dom: 18.2.0_react@18.2.0
   shiki: 0.14.0
@@ -268,6 +268,16 @@ packages:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.15.0
+
+  /@notionhq/client/2.2.3:
+    resolution: {integrity: sha512-ZqUzY0iRg/LIrwS+wzz/6osSB2nxIpmqdAtdUwzpcimc9Jlu1j85FeYdaU26Shr193CFrl2TLFeKqpk/APRQ4g==}
+    engines: {node: '>=12'}
+    dependencies:
+      '@types/node-fetch': 2.6.2
+      node-fetch: 2.6.9
+    transitivePeerDependencies:
+      - encoding
+    dev: false
 
   /@pkgr/utils/2.3.1:
     resolution: {integrity: sha512-wfzX8kc1PMyUILA+1Z/EqoE4UCXGy0iRGMhPwdfae1+f0OXlLqCk+By+aMzgJBzR9AzS4CDizioG6Ss1gvAFJw==}
@@ -644,45 +654,21 @@ packages:
     resolution: {integrity: sha512-sXo/qW2/pAcmT43VoRKOJbDOfV3cYpq3szSVfIThQXNt+E4DfKj361vaAt3c88U5tPUxzEswam7GW48PJqtKAg==}
     dev: false
 
-  /@sindresorhus/is/4.6.0:
-    resolution: {integrity: sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==}
-    engines: {node: '>=10'}
-    dev: false
-
   /@swc/helpers/0.4.14:
     resolution: {integrity: sha512-4C7nX/dvpzB7za4Ql9K81xK3HPxCpHMgwTZVyf+9JQ6VUbn9jjZVN7/Nkdz/Ugzs2CSjqnL/UPXroiVBVHUWUw==}
     dependencies:
       tslib: 2.5.0
     dev: false
 
-  /@szmarczak/http-timer/4.0.6:
-    resolution: {integrity: sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==}
-    engines: {node: '>=10'}
-    dependencies:
-      defer-to-connect: 2.0.1
-    dev: false
-
-  /@types/cacheable-request/6.0.3:
-    resolution: {integrity: sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==}
-    dependencies:
-      '@types/http-cache-semantics': 4.0.1
-      '@types/keyv': 3.1.4
-      '@types/node': 18.13.0
-      '@types/responselike': 1.0.0
-    dev: false
-
-  /@types/http-cache-semantics/4.0.1:
-    resolution: {integrity: sha512-SZs7ekbP8CN0txVG2xVRH6EgKmEm31BOxA07vkFaETzZz1xh+cbt8BcI0slpymvwhx5dlFnQG2rTlPVQn+iRPQ==}
-    dev: false
-
   /@types/json5/0.0.29:
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
     dev: false
 
-  /@types/keyv/3.1.4:
-    resolution: {integrity: sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==}
+  /@types/node-fetch/2.6.2:
+    resolution: {integrity: sha512-DHqhlq5jeESLy19TYhLakJ07kNumXWjcDdxXsLUMJZ6ue8VZJj4kLPQVE/2mdHh3xZziNF1xppu5lwmS53HR+A==}
     dependencies:
       '@types/node': 18.13.0
+      form-data: 3.0.1
     dev: false
 
   /@types/node/18.13.0:
@@ -705,12 +691,6 @@ packages:
       '@types/prop-types': 15.7.5
       '@types/scheduler': 0.16.2
       csstype: 3.1.1
-    dev: false
-
-  /@types/responselike/1.0.0:
-    resolution: {integrity: sha512-85Y2BjiufFzaMIlvJDvTTB8Fxl2xfLo4HgmHzVBz08w4wDePCTjYw66PdrolO0kzli3yam/YCgRufyo1DdQVTA==}
-    dependencies:
-      '@types/node': 18.13.0
     dev: false
 
   /@types/scheduler/0.16.2:
@@ -807,14 +787,6 @@ packages:
     resolution: {integrity: sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==}
     engines: {node: '>=0.4.0'}
     hasBin: true
-    dev: false
-
-  /aggregate-error/4.0.1:
-    resolution: {integrity: sha512-0poP0T7el6Vq3rstR8Mn4V/IQrpBLO6POkUSrN7RhyY+GF/InCFShQzsQ39T25gkHhLgSLByyAz+Kjb+c2L98w==}
-    engines: {node: '>=12'}
-    dependencies:
-      clean-stack: 4.2.0
-      indent-string: 5.0.0
     dev: false
 
   /ajv/6.12.6:
@@ -927,6 +899,10 @@ packages:
     resolution: {integrity: sha512-eBvWn1lvIApYMhzQMsu9ciLfkBY499mFZlNqG+/9WR7PVlroQw0vG30cOQQbaKz3sCEc44TAOu2ykzqXSNnwag==}
     dev: false
 
+  /asynckit/0.4.0:
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+    dev: false
+
   /autoprefixer/10.4.13_postcss@8.4.21:
     resolution: {integrity: sha512-49vKpMqcZYsJjwotvt4+h/BCjJVnhGwcLpDt5xkcaOG3eLrG/HUYLagrihYsQ+qrIBgIzX1Rw7a6L8I/ZA1Atg==}
     engines: {node: ^10 || ^12 || >=14}
@@ -991,24 +967,6 @@ packages:
       update-browserslist-db: 1.0.10_browserslist@4.21.5
     dev: true
 
-  /cacheable-lookup/5.0.4:
-    resolution: {integrity: sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==}
-    engines: {node: '>=10.6.0'}
-    dev: false
-
-  /cacheable-request/7.0.2:
-    resolution: {integrity: sha512-pouW8/FmiPQbuGpkXQ9BAPv/Mo5xDGANgSNXzTzJ8DrKGuXOssM4wIQRjfanNRh3Yu5cfYPvcorqbhg2KIJtew==}
-    engines: {node: '>=8'}
-    dependencies:
-      clone-response: 1.0.3
-      get-stream: 5.2.0
-      http-cache-semantics: 4.1.1
-      keyv: 4.5.2
-      lowercase-keys: 2.0.0
-      normalize-url: 6.1.0
-      responselike: 2.0.1
-    dev: false
-
   /call-bind/1.0.2:
     resolution: {integrity: sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==}
     dependencies:
@@ -1050,21 +1008,8 @@ packages:
     optionalDependencies:
       fsevents: 2.3.2
 
-  /clean-stack/4.2.0:
-    resolution: {integrity: sha512-LYv6XPxoyODi36Dp976riBtSY27VmFo+MKqEU9QCCWyTrdEPDog+RWA7xQWHi6Vbp61j5c4cdzzX1NidnwtUWg==}
-    engines: {node: '>=12'}
-    dependencies:
-      escape-string-regexp: 5.0.0
-    dev: false
-
   /client-only/0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
-    dev: false
-
-  /clone-response/1.0.3:
-    resolution: {integrity: sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==}
-    dependencies:
-      mimic-response: 1.0.1
     dev: false
 
   /color-convert/2.0.1:
@@ -1076,6 +1021,13 @@ packages:
 
   /color-name/1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  /combined-stream/1.0.8:
+    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
+    engines: {node: '>= 0.8'}
+    dependencies:
+      delayed-stream: 1.0.0
+    dev: false
 
   /concat-map/0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
@@ -1126,13 +1078,6 @@ packages:
       ms: 2.1.2
     dev: false
 
-  /decompress-response/6.0.0:
-    resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
-    engines: {node: '>=10'}
-    dependencies:
-      mimic-response: 3.1.0
-    dev: false
-
   /deep-equal/2.2.0:
     resolution: {integrity: sha512-RdpzE0Hv4lhowpIUKKMJfeH6C1pXdtT1/it80ubgWqwI3qpuxUBpC1S4hnHg+zjnuOoDkzUtUCEEkG+XG5l3Mw==}
     dependencies:
@@ -1159,11 +1104,6 @@ packages:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
     dev: false
 
-  /defer-to-connect/2.0.1:
-    resolution: {integrity: sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==}
-    engines: {node: '>=10'}
-    dev: false
-
   /define-lazy-prop/2.0.0:
     resolution: {integrity: sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==}
     engines: {node: '>=8'}
@@ -1179,6 +1119,11 @@ packages:
 
   /defined/1.0.1:
     resolution: {integrity: sha512-hsBd2qSVCRE+5PmNdHt1uzyrFu5d3RwmFDKzyNZMFq/EwDNJF7Ee5+D5oEKF0hU6LhtoUF1macFvOe4AskQC1Q==}
+
+  /delayed-stream/1.0.0:
+    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
+    engines: {node: '>=0.4.0'}
+    dev: false
 
   /detect-node-es/1.1.0:
     resolution: {integrity: sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==}
@@ -1226,12 +1171,6 @@ packages:
 
   /emoji-regex/9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
-    dev: false
-
-  /end-of-stream/1.4.4:
-    resolution: {integrity: sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==}
-    dependencies:
-      once: 1.4.0
     dev: false
 
   /enhanced-resolve/5.12.0:
@@ -1327,11 +1266,6 @@ packages:
   /escape-string-regexp/4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
-    dev: false
-
-  /escape-string-regexp/5.0.0:
-    resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
-    engines: {node: '>=12'}
     dev: false
 
   /eslint-config-next/13.1.6_4vsywjlpuriuw3tl5oq6zy5a64:
@@ -1619,10 +1553,6 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: false
 
-  /eventemitter3/4.0.7:
-    resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
-    dev: false
-
   /fast-deep-equal/3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
     dev: false
@@ -1689,6 +1619,15 @@ packages:
       is-callable: 1.2.7
     dev: false
 
+  /form-data/3.0.1:
+    resolution: {integrity: sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==}
+    engines: {node: '>= 6'}
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      mime-types: 2.1.35
+    dev: false
+
   /fraction.js/4.2.0:
     resolution: {integrity: sha512-MhLuK+2gUcnZe8ZHlaaINnQLl0xRIGRfcGk2yl8xoQAfHrSsL3rYu6FCmBdkdbhc9EPlwyGHewaRsvwRMJtAlA==}
     dev: true
@@ -1732,13 +1671,6 @@ packages:
   /get-nonce/1.0.1:
     resolution: {integrity: sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==}
     engines: {node: '>=6'}
-    dev: false
-
-  /get-stream/5.2.0:
-    resolution: {integrity: sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==}
-    engines: {node: '>=8'}
-    dependencies:
-      pump: 3.0.0
     dev: false
 
   /get-symbol-description/1.0.0:
@@ -1838,23 +1770,6 @@ packages:
       get-intrinsic: 1.2.0
     dev: false
 
-  /got/11.8.6:
-    resolution: {integrity: sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==}
-    engines: {node: '>=10.19.0'}
-    dependencies:
-      '@sindresorhus/is': 4.6.0
-      '@szmarczak/http-timer': 4.0.6
-      '@types/cacheable-request': 6.0.3
-      '@types/responselike': 1.0.0
-      cacheable-lookup: 5.0.4
-      cacheable-request: 7.0.2
-      decompress-response: 6.0.0
-      http2-wrapper: 1.0.3
-      lowercase-keys: 2.0.0
-      p-cancelable: 2.1.1
-      responselike: 2.0.1
-    dev: false
-
   /graceful-fs/4.2.10:
     resolution: {integrity: sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==}
     dev: false
@@ -1901,18 +1816,6 @@ packages:
     dependencies:
       function-bind: 1.1.1
 
-  /http-cache-semantics/4.1.1:
-    resolution: {integrity: sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==}
-    dev: false
-
-  /http2-wrapper/1.0.3:
-    resolution: {integrity: sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==}
-    engines: {node: '>=10.19.0'}
-    dependencies:
-      quick-lru: 5.1.1
-      resolve-alpn: 1.2.1
-    dev: false
-
   /ignore/5.2.4:
     resolution: {integrity: sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==}
     engines: {node: '>= 4'}
@@ -1929,11 +1832,6 @@ packages:
   /imurmurhash/0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
-    dev: false
-
-  /indent-string/5.0.0:
-    resolution: {integrity: sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==}
-    engines: {node: '>=12'}
     dev: false
 
   /inflight/1.0.6:
@@ -2099,11 +1997,6 @@ packages:
       has-tostringtag: 1.0.0
     dev: false
 
-  /is-url-superb/6.1.0:
-    resolution: {integrity: sha512-LXdhGlYqUPdvEyIhWPEEwYYK3yrUiPcBjmFGlZNv1u5GtIL5qQRf7ddDyPNAvsMFqdzS923FROpTQU97tLe3JQ==}
-    engines: {node: '>=12'}
-    dev: false
-
   /is-weakmap/2.0.1:
     resolution: {integrity: sha512-NSBR4kH5oVj1Uwvv970ruUkCV7O1mzgVFO4/rev2cLRda9Tm9HrL70ZPut4rOHgY0FNrUu9BCbXA2sdQ+x0chA==}
     dev: false
@@ -2151,10 +2044,6 @@ packages:
       argparse: 2.0.1
     dev: false
 
-  /json-buffer/3.0.1:
-    resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
-    dev: false
-
   /json-schema-traverse/0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
     dev: false
@@ -2180,12 +2069,6 @@ packages:
     dependencies:
       array-includes: 3.1.6
       object.assign: 4.1.4
-    dev: false
-
-  /keyv/4.5.2:
-    resolution: {integrity: sha512-5MHbFaKn8cNSmVW7BYnijeAVlE4cYA/SVkifVgrh7yotnfhKmjuXpDKjrABLnT0SfHWV21P8ow07OGfRrNDg8g==}
-    dependencies:
-      json-buffer: 3.0.1
     dev: false
 
   /language-subtag-registry/0.3.22:
@@ -2228,11 +2111,6 @@ packages:
       js-tokens: 4.0.0
     dev: false
 
-  /lowercase-keys/2.0.0:
-    resolution: {integrity: sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==}
-    engines: {node: '>=8'}
-    dev: false
-
   /lru-cache/6.0.0:
     resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
     engines: {node: '>=10'}
@@ -2248,21 +2126,6 @@ packages:
       react: 18.2.0
     dev: false
 
-  /map-age-cleaner/0.1.3:
-    resolution: {integrity: sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==}
-    engines: {node: '>=6'}
-    dependencies:
-      p-defer: 1.0.0
-    dev: false
-
-  /mem/9.0.2:
-    resolution: {integrity: sha512-F2t4YIv9XQUBHt6AOJ0y7lSmP1+cY7Fm1DRh9GClTGzKST7UWLMx6ly9WZdLH/G/ppM5RL4MlQfRT71ri9t19A==}
-    engines: {node: '>=12.20'}
-    dependencies:
-      map-age-cleaner: 0.1.3
-      mimic-fn: 4.0.0
-    dev: false
-
   /merge2/1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
@@ -2274,19 +2137,16 @@ packages:
       braces: 3.0.2
       picomatch: 2.3.1
 
-  /mimic-fn/4.0.0:
-    resolution: {integrity: sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==}
-    engines: {node: '>=12'}
+  /mime-db/1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
     dev: false
 
-  /mimic-response/1.0.1:
-    resolution: {integrity: sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==}
-    engines: {node: '>=4'}
-    dev: false
-
-  /mimic-response/3.1.0:
-    resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
-    engines: {node: '>=10'}
+  /mime-types/2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
+    engines: {node: '>= 0.6'}
+    dependencies:
+      mime-db: 1.52.0
     dev: false
 
   /minimatch/3.1.2:
@@ -2359,6 +2219,18 @@ packages:
       - babel-plugin-macros
     dev: false
 
+  /node-fetch/2.6.9:
+    resolution: {integrity: sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
+    dependencies:
+      whatwg-url: 5.0.0
+    dev: false
+
   /node-releases/2.0.10:
     resolution: {integrity: sha512-5GFldHPXVG/YZmFzJvKK2zDSzPKhEp0+ZR5SVaoSag9fsL5YgHbUHDfnG5494ISANDcK4KwPXAx2xqVEydmd7w==}
     dev: true
@@ -2371,42 +2243,6 @@ packages:
     resolution: {integrity: sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==}
     engines: {node: '>=0.10.0'}
     dev: true
-
-  /normalize-url/6.1.0:
-    resolution: {integrity: sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==}
-    engines: {node: '>=10'}
-    dev: false
-
-  /normalize-url/7.2.0:
-    resolution: {integrity: sha512-uhXOdZry0L6M2UIo9BTt7FdpBDiAGN/7oItedQwPKh8jh31ZlvC8U9Xl/EJ3aijDHaywXTW3QbZ6LuCocur1YA==}
-    engines: {node: '>=12.20'}
-    dev: false
-
-  /notion-client/6.16.0:
-    resolution: {integrity: sha512-gI2kPpls8XxJfXt7cs2JDmSHPZL1HkkXQnE5YWKPT4OnpiniUgHk5b+rRB2dXUqGT4003vSYmPnxXUTbzKPoLA==}
-    engines: {node: '>=12'}
-    dependencies:
-      got: 11.8.6
-      notion-types: 6.16.0
-      notion-utils: 6.16.0
-      p-map: 5.5.0
-    dev: false
-
-  /notion-types/6.16.0:
-    resolution: {integrity: sha512-Cv83GaAczx57q1qsnuG8DHOuOb63c83u9LX2IainG5aqBEB0GUuLZ4DUQfB6MaXt+FMY9fO+KTgPeZWwX9hbrQ==}
-    engines: {node: '>=12'}
-    dev: false
-
-  /notion-utils/6.16.0:
-    resolution: {integrity: sha512-DxToriZAJW/64O1xlAjyU/50dRmkO1e54+i0dEAPDij0MlHyihEivAMsdEG/6/4eFC972BIsEKZ6BXsSTUYKlQ==}
-    engines: {node: '>=12'}
-    dependencies:
-      is-url-superb: 6.1.0
-      mem: 9.0.2
-      normalize-url: 7.2.0
-      notion-types: 6.16.0
-      p-queue: 7.3.4
-    dev: false
 
   /object-assign/4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
@@ -2505,16 +2341,6 @@ packages:
       word-wrap: 1.2.3
     dev: false
 
-  /p-cancelable/2.1.1:
-    resolution: {integrity: sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==}
-    engines: {node: '>=8'}
-    dev: false
-
-  /p-defer/1.0.0:
-    resolution: {integrity: sha512-wB3wfAxZpk2AzOfUMJNL+d36xothRSyj8EXOa4f6GMqYDN9BJaaSISbsk+wS9abmnebVw95C2Kb5t85UmpCxuw==}
-    engines: {node: '>=4'}
-    dev: false
-
   /p-limit/3.1.0:
     resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
     engines: {node: '>=10'}
@@ -2527,26 +2353,6 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       p-limit: 3.1.0
-    dev: false
-
-  /p-map/5.5.0:
-    resolution: {integrity: sha512-VFqfGDHlx87K66yZrNdI4YGtD70IRyd+zSvgks6mzHPRNkoKy+9EKP4SFC77/vTTQYmRmti7dvqC+m5jBrBAcg==}
-    engines: {node: '>=12'}
-    dependencies:
-      aggregate-error: 4.0.1
-    dev: false
-
-  /p-queue/7.3.4:
-    resolution: {integrity: sha512-esox8CWt0j9EZECFvkFl2WNPat8LN4t7WWeXq73D9ha0V96qPRufApZi4ZhPwXAln1uVVal429HVVKPa2X0yQg==}
-    engines: {node: '>=12'}
-    dependencies:
-      eventemitter3: 4.0.7
-      p-timeout: 5.1.0
-    dev: false
-
-  /p-timeout/5.1.0:
-    resolution: {integrity: sha512-auFDyzzzGZZZdHz3BtET9VEz0SE/uMEAx7uWfGPucfzEwwe/xH0iVeZibQmANYE/hp9T2+UUZT5m+BKyrDp3Ew==}
-    engines: {node: '>=12'}
     dev: false
 
   /parent-module/1.0.1:
@@ -2675,13 +2481,6 @@ packages:
       react-is: 16.13.1
     dev: false
 
-  /pump/3.0.0:
-    resolution: {integrity: sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==}
-    dependencies:
-      end-of-stream: 1.4.4
-      once: 1.4.0
-    dev: false
-
   /punycode/2.3.0:
     resolution: {integrity: sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==}
     engines: {node: '>=6'}
@@ -2796,10 +2595,6 @@ packages:
     engines: {node: '>=8'}
     dev: false
 
-  /resolve-alpn/1.2.1:
-    resolution: {integrity: sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==}
-    dev: false
-
   /resolve-from/4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
@@ -2820,12 +2615,6 @@ packages:
       is-core-module: 2.11.0
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
-    dev: false
-
-  /responselike/2.0.1:
-    resolution: {integrity: sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==}
-    dependencies:
-      lowercase-keys: 2.0.0
     dev: false
 
   /reusify/1.0.4:
@@ -3067,6 +2856,10 @@ packages:
     dependencies:
       is-number: 7.0.0
 
+  /tr46/0.0.3:
+    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+    dev: false
+
   /tsconfig-paths/3.14.1:
     resolution: {integrity: sha512-fxDhWnFSLt3VuTwtvJt5fpwxBHg5AdKWMsgcPOOIilyjymcYVZoCQF8fvFRezCNfblEXmi+PcM1eYHeOAgXCOQ==}
     dependencies:
@@ -3199,6 +2992,17 @@ packages:
 
   /vscode-textmate/8.0.0:
     resolution: {integrity: sha512-AFbieoL7a5LMqcnOF04ji+rpXadgOXnZsxQr//r83kLPr7biP7am3g9zbaZIaBGwBRWeSvoMD4mgPdX3e4NWBg==}
+    dev: false
+
+  /webidl-conversions/3.0.1:
+    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+    dev: false
+
+  /whatwg-url/5.0.0:
+    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
+    dependencies:
+      tr46: 0.0.3
+      webidl-conversions: 3.0.1
     dev: false
 
   /which-boxed-primitive/1.0.2:

--- a/src/app/others/dev-setup/page.tsx
+++ b/src/app/others/dev-setup/page.tsx
@@ -1,5 +1,6 @@
 import { CodePreview } from '@/components/CodePreview'
 import { getCodeBlockFromNotion } from '@/lib/notion-client'
+import { getNotionPagesId } from '@/lib/vercel-edge-config'
 import shiki from 'shiki'
 
 export const metadata = {
@@ -14,10 +15,11 @@ export const metadata = {
 
 // That's it, nothing more.
 // `.trim()
- 
+
 export default async function DevSetup() {
-  const { content } = await getCodeBlockFromNotion("3ef135df776c4b359c3c2a5974c31c06")
-  
+  const { devSetup } = await getNotionPagesId()
+  const { content } = await getCodeBlockFromNotion(devSetup)
+
   const highlighter = await shiki.getHighlighter({
     theme: 'rose-pine-moon',
   })

--- a/src/app/others/dev-setup/page.tsx
+++ b/src/app/others/dev-setup/page.tsx
@@ -1,25 +1,28 @@
 import { CodePreview } from '@/components/CodePreview'
+import { getCodeBlockFromNotion } from '@/lib/notion-client'
 import shiki from 'shiki'
 
 export const metadata = {
   title: 'Dev Setup',
 }
 
-const markdown = `
-# Dev Setup
+// const markdown = `
+// # Dev Setup
 
-- MacBook M1 Max (64gb Memory)
-- LG 25" UltraWide Display
+// - MacBook M1 Max (64gb Memory)
+// - LG 25" UltraWide Display
 
-That's it, nothing more.
-`.trim()
+// That's it, nothing more.
+// `.trim()
  
 export default async function DevSetup() {
+  const { content } = await getCodeBlockFromNotion("3ef135df776c4b359c3c2a5974c31c06")
+  
   const highlighter = await shiki.getHighlighter({
     theme: 'rose-pine-moon',
   })
 
-  const code = highlighter.codeToHtml(markdown, { lang: 'md' })
+  const code = highlighter.codeToHtml(content, { lang: 'md' })
 
   return <CodePreview code={code} />
 }

--- a/src/app/others/dev-setup/page.tsx
+++ b/src/app/others/dev-setup/page.tsx
@@ -7,18 +7,9 @@ export const metadata = {
   title: 'Dev Setup',
 }
 
-// const markdown = `
-// # Dev Setup
-
-// - MacBook M1 Max (64gb Memory)
-// - LG 25" UltraWide Display
-
-// That's it, nothing more.
-// `.trim()
-
 export default async function DevSetup() {
-  const { devSetup } = await getNotionPagesId()
-  const { content } = await getCodeBlockFromNotion(devSetup)
+  const { setup_dev } = await getNotionPagesId()
+  const { content } = await getCodeBlockFromNotion(setup_dev)
 
   const highlighter = await shiki.getHighlighter({
     theme: 'rose-pine-moon',

--- a/src/app/others/gaming-setup/page.tsx
+++ b/src/app/others/gaming-setup/page.tsx
@@ -1,5 +1,6 @@
 import { CodePreview } from '@/components/CodePreview'
 import { getCodeBlockFromNotion } from '@/lib/notion-client'
+import { getNotionPagesId } from '@/lib/vercel-edge-config'
 import shiki from 'shiki'
 
 export const metadata = {
@@ -25,10 +26,11 @@ export const metadata = {
 
 // That's it, nothing more.
 // `.trim()
- 
+
 export default async function GamingSetup() {
-  const { content } = await getCodeBlockFromNotion("1e3d4fc933cf4d30917acf99437e3a83")
-  
+  const { gamingSetup } = await getNotionPagesId()
+  const { content } = await getCodeBlockFromNotion(gamingSetup)
+
   const highlighter = await shiki.getHighlighter({
     theme: 'rose-pine-moon',
   })

--- a/src/app/others/gaming-setup/page.tsx
+++ b/src/app/others/gaming-setup/page.tsx
@@ -1,36 +1,39 @@
 import { CodePreview } from '@/components/CodePreview'
+import { getCodeBlockFromNotion } from '@/lib/notion-client'
 import shiki from 'shiki'
 
 export const metadata = {
   title: 'Gaming Setup',
 }
 
-const markdown = `
-# Gaming Setup
+// const markdown = `
+// # Gaming Setup
 
-- Intel Core i5-9600KF 3.7Ghz
-- 2x HyperX Fury 16GB 3000Mhz
-- Gigabyte Z390M Gaming
-- Cooler Master ATX 500W 80 Plus
-- 2x Corsair SSD MP510 480GB NVMe
-- Gigabyte NVIDIA GeForce RTX 2060 6G
+// - Intel Core i5-9600KF 3.7Ghz
+// - 2x HyperX Fury 16GB 3000Mhz
+// - Gigabyte Z390M Gaming
+// - Cooler Master ATX 500W 80 Plus
+// - 2x Corsair SSD MP510 480GB NVMe
+// - Gigabyte NVIDIA GeForce RTX 2060 6G
 
 
-## Peripherals
+// ## Peripherals
 
-- Logitech G PRO Wireless Mouse
-- Keychron K2 Keyboard (Brown Switch)
-- Samsung 23.5" Curved 144hz 1ms Display
+// - Logitech G PRO Wireless Mouse
+// - Keychron K2 Keyboard (Brown Switch)
+// - Samsung 23.5" Curved 144hz 1ms Display
 
-That's it, nothing more.
-`.trim()
+// That's it, nothing more.
+// `.trim()
  
 export default async function GamingSetup() {
+  const { content } = await getCodeBlockFromNotion("1e3d4fc933cf4d30917acf99437e3a83")
+  
   const highlighter = await shiki.getHighlighter({
     theme: 'rose-pine-moon',
   })
 
-  const code = highlighter.codeToHtml(markdown, { lang: 'md' })
+  const code = highlighter.codeToHtml(content, { lang: 'md' })
 
   return <CodePreview code={code} />
 }

--- a/src/app/others/gaming-setup/page.tsx
+++ b/src/app/others/gaming-setup/page.tsx
@@ -7,29 +7,9 @@ export const metadata = {
   title: 'Gaming Setup',
 }
 
-// const markdown = `
-// # Gaming Setup
-
-// - Intel Core i5-9600KF 3.7Ghz
-// - 2x HyperX Fury 16GB 3000Mhz
-// - Gigabyte Z390M Gaming
-// - Cooler Master ATX 500W 80 Plus
-// - 2x Corsair SSD MP510 480GB NVMe
-// - Gigabyte NVIDIA GeForce RTX 2060 6G
-
-
-// ## Peripherals
-
-// - Logitech G PRO Wireless Mouse
-// - Keychron K2 Keyboard (Brown Switch)
-// - Samsung 23.5" Curved 144hz 1ms Display
-
-// That's it, nothing more.
-// `.trim()
-
 export default async function GamingSetup() {
-  const { gamingSetup } = await getNotionPagesId()
-  const { content } = await getCodeBlockFromNotion(gamingSetup)
+  const { setup_gaming } = await getNotionPagesId()
+  const { content } = await getCodeBlockFromNotion(setup_gaming)
 
   const highlighter = await shiki.getHighlighter({
     theme: 'rose-pine-moon',

--- a/src/app/terminal/fish/page.tsx
+++ b/src/app/terminal/fish/page.tsx
@@ -7,20 +7,9 @@ export const metadata = {
   title: 'Fish',
 }
 
-// const fishConfig = `if status is-interactive
-// # Commands to run in interactive sessions can go here
-// end
-
-// set SPACEFISH_PROMPT_ADD_NEWLINE false
-
-// starship init fish | source
-
-// # Aliases
-// # alias cat="bat --theme=\$(defaults read -globalDomain AppleInterfaceStyle &> /dev/null && echo default || echo GitHub)"`
-
 export default async function FishConfig() {
-  const { fish } = await getNotionPagesId()
-  const { content } = await getCodeBlockFromNotion(fish)
+  const { terminal_fish } = await getNotionPagesId()
+  const { content } = await getCodeBlockFromNotion(terminal_fish)
 
   const highlighter = await shiki.getHighlighter({
     theme: 'rose-pine-moon',

--- a/src/app/terminal/fish/page.tsx
+++ b/src/app/terminal/fish/page.tsx
@@ -1,5 +1,6 @@
 import { CodePreview } from '@/components/CodePreview'
 import { getCodeBlockFromNotion } from '@/lib/notion-client'
+import { getNotionPagesId } from '@/lib/vercel-edge-config'
 import shiki from 'shiki'
 
 export const metadata = {
@@ -18,7 +19,8 @@ export const metadata = {
 // # alias cat="bat --theme=\$(defaults read -globalDomain AppleInterfaceStyle &> /dev/null && echo default || echo GitHub)"`
 
 export default async function FishConfig() {
-  const { content } = await getCodeBlockFromNotion("801ef0fa04c542ec828881fb41382537")
+  const { fish } = await getNotionPagesId()
+  const { content } = await getCodeBlockFromNotion(fish)
 
   const highlighter = await shiki.getHighlighter({
     theme: 'rose-pine-moon',

--- a/src/app/terminal/fish/page.tsx
+++ b/src/app/terminal/fish/page.tsx
@@ -1,27 +1,30 @@
 import { CodePreview } from '@/components/CodePreview'
+import { getCodeBlockFromNotion } from '@/lib/notion-client'
 import shiki from 'shiki'
 
 export const metadata = {
   title: 'Fish',
 }
 
-const fishConfig = `if status is-interactive
-# Commands to run in interactive sessions can go here
-end
+// const fishConfig = `if status is-interactive
+// # Commands to run in interactive sessions can go here
+// end
 
-set SPACEFISH_PROMPT_ADD_NEWLINE false
+// set SPACEFISH_PROMPT_ADD_NEWLINE false
 
-starship init fish | source
+// starship init fish | source
 
-# Aliases
-# alias cat="bat --theme=\$(defaults read -globalDomain AppleInterfaceStyle &> /dev/null && echo default || echo GitHub)"`
+// # Aliases
+// # alias cat="bat --theme=\$(defaults read -globalDomain AppleInterfaceStyle &> /dev/null && echo default || echo GitHub)"`
 
 export default async function FishConfig() {
+  const { content } = await getCodeBlockFromNotion("801ef0fa04c542ec828881fb41382537")
+
   const highlighter = await shiki.getHighlighter({
     theme: 'rose-pine-moon',
   })
 
-  const code = highlighter.codeToHtml(fishConfig, { lang: 'fish' })
+  const code = highlighter.codeToHtml(content, { lang: 'fish' })
 
-  return <CodePreview code={code} raw={fishConfig} />
+  return <CodePreview code={code} raw={content} />
 }

--- a/src/app/terminal/general/page.tsx
+++ b/src/app/terminal/general/page.tsx
@@ -3,35 +3,13 @@ import { getCodeBlockFromNotion } from '@/lib/notion-client'
 import { getNotionPagesId } from '@/lib/vercel-edge-config'
 import shiki from 'shiki'
 
-
 export const metadata = {
   title: 'Terminal',
 }
 
-// const markdown = `
-// # General
-
-// Currently I'm using the combo Fish + Starship in my terminal.
-
-// Fish Shell: https://fishshell.com/
-// Starship: https://starship.rs/
-
-// ---
-
-// I'm also using Warp as my terminal emulator.
-
-// Warp: https://www.warp.dev/
-
-// ---
-
-// For the theme, I chose Rosé Pine Moon variant:
-
-// Theme: https://github.com/austintraver/warp-theme/blob/main/base16_rose_pine_moon.yaml
-// `.trim()
-
 export default async function General() {
-  const { general } = await getNotionPagesId()
-  const { content } = await getCodeBlockFromNotion(general)
+  const { terminal_general } = await getNotionPagesId()
+  const { content } = await getCodeBlockFromNotion(terminal_general)
 
   const highlighter = await shiki.getHighlighter({
     theme: 'rose-pine-moon',

--- a/src/app/terminal/general/page.tsx
+++ b/src/app/terminal/general/page.tsx
@@ -1,5 +1,6 @@
 import { CodePreview } from '@/components/CodePreview'
 import { getCodeBlockFromNotion } from '@/lib/notion-client'
+import { getNotionPagesId } from '@/lib/vercel-edge-config'
 import shiki from 'shiki'
 
 
@@ -29,8 +30,9 @@ export const metadata = {
 // `.trim()
 
 export default async function General() {
-  const { content } = await getCodeBlockFromNotion("19308817500d4b3ca1f48b4b928911be")
-  
+  const { general } = await getNotionPagesId()
+  const { content } = await getCodeBlockFromNotion(general)
+
   const highlighter = await shiki.getHighlighter({
     theme: 'rose-pine-moon',
   })

--- a/src/app/terminal/general/page.tsx
+++ b/src/app/terminal/general/page.tsx
@@ -1,37 +1,41 @@
 import { CodePreview } from '@/components/CodePreview'
+import { getCodeBlockFromNotion } from '@/lib/notion-client'
 import shiki from 'shiki'
+
 
 export const metadata = {
   title: 'Terminal',
 }
 
-const markdown = `
-# General
+// const markdown = `
+// # General
 
-Currently I'm using the combo Fish + Starship in my terminal.
+// Currently I'm using the combo Fish + Starship in my terminal.
 
-Fish Shell: https://fishshell.com/
-Starship: https://starship.rs/
+// Fish Shell: https://fishshell.com/
+// Starship: https://starship.rs/
 
----
+// ---
 
-I'm also using Warp as my terminal emulator.
+// I'm also using Warp as my terminal emulator.
 
-Warp: https://www.warp.dev/
+// Warp: https://www.warp.dev/
 
----
+// ---
 
-For the theme, I chose Rosé Pine Moon variant: 
+// For the theme, I chose Rosé Pine Moon variant:
 
-Theme: https://github.com/austintraver/warp-theme/blob/main/base16_rose_pine_moon.yaml
-`.trim()
+// Theme: https://github.com/austintraver/warp-theme/blob/main/base16_rose_pine_moon.yaml
+// `.trim()
 
 export default async function General() {
+  const { content } = await getCodeBlockFromNotion("19308817500d4b3ca1f48b4b928911be")
+  
   const highlighter = await shiki.getHighlighter({
     theme: 'rose-pine-moon',
   })
 
-  const code = highlighter.codeToHtml(markdown, { lang: 'md' })
+  const code = highlighter.codeToHtml(content, { lang: 'md' })
 
   return <CodePreview code={code} />
 }

--- a/src/lib/notion-client.ts
+++ b/src/lib/notion-client.ts
@@ -5,14 +5,7 @@ export const notionClient = new Client({ auth: process.env.NOTION_API_KEY })
 export async function getCodeBlockFromNotion(pageId: string) {
   const { results } = await notionClient.blocks.children.list({ block_id: pageId })
 
-  let codeBlock
-
-  for (let block of results) {
-    if (isFullBlock(block) && block.type === "code") {
-      codeBlock = block
-      break
-    }
-  }
+  const codeBlock = results.find(block => isFullBlock(block) && block.type === "code")
 
   if (!codeBlock) {
     throw new Error(`Failed to fetch Notion content of ID: ${pageId}`)

--- a/src/lib/notion-client.ts
+++ b/src/lib/notion-client.ts
@@ -1,0 +1,19 @@
+import { NotionAPI } from "notion-client";
+
+export const notionClient = new NotionAPI();
+
+export async function getCodeBlockFromNotion(pageId: string) {
+  const page = await notionClient.getPage(pageId)
+  const blocks = Object.entries(page.block).map(
+    ([key, value]) => ({ ...value })
+  )
+  const codeBlock = blocks.find(block => block.value.type === "code")
+
+  if (!codeBlock) {
+    throw new Error("Error when trying to fetch Notion pages")
+  }
+
+  const codeBlockContent = codeBlock.value.properties.title[0][0] as string
+  
+  return { content: codeBlockContent }
+}

--- a/src/lib/notion-client.ts
+++ b/src/lib/notion-client.ts
@@ -1,11 +1,14 @@
 import { Client, isFullBlock } from "@notionhq/client"
+import { CodeBlockObjectResponse } from "@notionhq/client/build/src/api-endpoints"
 
 export const notionClient = new Client({ auth: process.env.NOTION_API_KEY })
 
 export async function getCodeBlockFromNotion(pageId: string) {
   const { results } = await notionClient.blocks.children.list({ block_id: pageId })
 
-  const codeBlock = results.find(block => isFullBlock(block) && block.type === "code")
+  const codeBlock = results.find(
+    block => isFullBlock(block) && block.type === "code"
+  ) as CodeBlockObjectResponse | undefined
 
   if (!codeBlock) {
     throw new Error(`Failed to fetch Notion content of ID: ${pageId}`)

--- a/src/lib/notion-client.ts
+++ b/src/lib/notion-client.ts
@@ -1,5 +1,5 @@
-import { Client, isFullBlock } from "@notionhq/client"
-import { CodeBlockObjectResponse } from "@notionhq/client/build/src/api-endpoints"
+import { Client, isFullBlock } from '@notionhq/client'
+import { CodeBlockObjectResponse } from '@notionhq/client/build/src/api-endpoints'
 
 export const notionClient = new Client({ auth: process.env.NOTION_API_KEY })
 
@@ -7,7 +7,7 @@ export async function getCodeBlockFromNotion(pageId: string) {
   const { results } = await notionClient.blocks.children.list({ block_id: pageId })
 
   const codeBlock = results.find(
-    block => isFullBlock(block) && block.type === "code"
+    block => isFullBlock(block) && block.type === 'code'
   ) as CodeBlockObjectResponse | undefined
 
   if (!codeBlock) {

--- a/src/lib/notion-client.ts
+++ b/src/lib/notion-client.ts
@@ -1,19 +1,24 @@
-import { NotionAPI } from "notion-client";
+import { Client, isFullBlock } from "@notionhq/client"
 
-export const notionClient = new NotionAPI();
+export const notionClient = new Client({ auth: process.env.NOTION_API_KEY })
 
 export async function getCodeBlockFromNotion(pageId: string) {
-  const page = await notionClient.getPage(pageId)
-  const blocks = Object.entries(page.block).map(
-    ([key, value]) => ({ ...value })
-  )
-  const codeBlock = blocks.find(block => block.value.type === "code")
+  const { results } = await notionClient.blocks.children.list({ block_id: pageId })
 
-  if (!codeBlock) {
-    throw new Error("Error when trying to fetch Notion pages")
+  let codeBlock
+
+  for (let block of results) {
+    if (isFullBlock(block) && block.type === "code") {
+      codeBlock = block
+      break
+    }
   }
 
-  const codeBlockContent = codeBlock.value.properties.title[0][0] as string
-  
-  return { content: codeBlockContent }
+  if (!codeBlock) {
+    throw new Error(`Failed to fetch Notion content of ID: ${pageId}`)
+  }
+
+  const { plain_text } = codeBlock.code.rich_text[0]
+
+  return { content: plain_text }
 }

--- a/src/lib/vercel-edge-config.ts
+++ b/src/lib/vercel-edge-config.ts
@@ -1,15 +1,15 @@
-import { getAll } from "@vercel/edge-config";
-import { z } from "zod";
+import { get } from '@vercel/edge-config'
+import { z } from 'zod'
 
 const notionPagesIdStore = z.object({
-  general: z.string(),
-  fish: z.string(),
-  devSetup: z.string(),
-  gamingSetup: z.string(),
+  terminal_general: z.string(),
+  terminal_fish: z.string(),
+  setup_dev: z.string(),
+  setup_gaming: z.string(),
 })
 
 export async function getNotionPagesId() {
-  const pagesId = await getAll()
+  const pagesId = await get('notion')
 
   return notionPagesIdStore.parse(pagesId)
 }

--- a/src/lib/vercel-edge-config.ts
+++ b/src/lib/vercel-edge-config.ts
@@ -1,0 +1,15 @@
+import { getAll } from "@vercel/edge-config";
+import { z } from "zod";
+
+const notionPagesIdStore = z.object({
+  general: z.string(),
+  fish: z.string(),
+  devSetup: z.string(),
+  gamingSetup: z.string(),
+})
+
+export async function getNotionPagesId() {
+  const pagesId = await getAll()
+
+  return notionPagesIdStore.parse(pagesId)
+}


### PR DESCRIPTION
To address issue #16 and provide guidance for potential solutions, I implemented a few changes:

- Utilized [`notion-client`](https://www.npmjs.com/package/notion-client) to fetch Notion pages
- Replaced hardcoded markdown and fish files with fetched Notion data

While I could have used the official Notion API, `notion-client` is a more lightweight option that does not require an API key. Instead, it simply requires the page ID from Notion.

To obtain the page ID, I followed these steps:

1. Created individual pages on Notion for each Next.js page

![Step 1](https://drive.google.com/uc?export=download&id=1-hX0OCU7SsbK_RtLBfgeM2Z3m5XZCxTZ)

2. Added a code block with the appropriate content to each page

![Step 2](https://drive.google.com/uc?export=download&id=1-h0zrFMI7j2sHbQsEpSMBY9eReMwJFhA)

3. Enabled "Share to web" and copied the page ID (the last part of the URL)

![Step 3](https://drive.google.com/uc?export=download&id=1-fhFmjnme0ydBr3wZLI07fYXRu2mogAC)

With the page IDs in hand, I passed them to the `getCodeBlockFromNotion` function to fetch their content.

---

As this is my first PR, I aimed to thoroughly explain the changes I made and hope they will be helpful.